### PR TITLE
Feature interstitial mixing

### DIFF
--- a/SD/index.html
+++ b/SD/index.html
@@ -304,6 +304,28 @@
             />
           </div>
 
+          <div class="formrow">
+            <label for="intermixtimes">Intermix times [ul]:</label>
+            <input
+              type="number"
+              id="intermixtimes"
+              name="intermixtimes"
+              placeholder="e.g. 3"
+              required
+            />
+          </div>
+
+          <div class="formrow">
+            <label for="intermixduration">Intermix duration [sec]:</label>
+            <input
+              type="number"
+              id="intermixduration"
+              name="intermixduration"
+              placeholder="e.g. 60"
+              required
+            />
+          </div>
+
           <div class="formrow" id="flow">
             <label for="flow_meas_time">Measure for [s]:</label>
             <input
@@ -449,6 +471,8 @@
     document.getElementById("co2interval").value = "@co2interval@";
     document.getElementById("co2lograte").value = "@co2lograte@";
     document.getElementById("soillograte").value = "@soillograte@";
+    document.getElementById("intermixtimes").value = "@intermixtimes@";
+    document.getElementById("intermixduration").value = "@intermixduration@";
     document.getElementById("warmupduration").value = "@warmupduration@";
     document.getElementById("premixduration").value = "@premixduration@";
     document.getElementById("valvesclosedduration").value =

--- a/include/config.h
+++ b/include/config.h
@@ -22,9 +22,8 @@ struct Config {
   int soil_interval = 6;    /* The interval at which the soil temp and soil
                                     moist sensors take measurements in seconds.
                                     Default 60s */
-  int sleep_duration = 180; // The sleep duration in minutes
+  int sleep_duration_minutes = 180; // The sleep duration in minutes
   int intermix_times = 0; // Number of times to wake up and run the fan only between measurements
-  int intermix_done_count = 0; // How many times we've intermixed so far, up to intermix_times
   int intermix_duration = 60; // Seconds to run fan for during intermix
   String logfilename = "temp.csv"; // File where measurements are stored.
   String serial_number = "";       // Serial number of the chamber

--- a/include/config.h
+++ b/include/config.h
@@ -23,6 +23,9 @@ struct Config {
                                     moist sensors take measurements in seconds.
                                     Default 60s */
   int sleep_duration = 180; // The sleep duration in minutes
+  int intermix_times = 0; // Number of times to wake up and run the fan only between measurements
+  int intermix_done_count = 0; // How many times we've intermixed so far, up to intermix_times
+  int intermix_duration = 60; // Seconds to run fan for during intermix
   String logfilename = "temp.csv"; // File where measurements are stored.
   String serial_number = "";       // Serial number of the chamber
 
@@ -45,13 +48,6 @@ struct Config {
   /* Return the current configuration as a JSON string */
   std::string dumps();
 
-  /** @deprecated Attempt to parse the configuration file at path on the given
-   * filesystem */
-  void readFrom(FS& fs, const char* path);
-
-  /** @deprecated Write the current configuration to the given path on the given
-  filesytem. Example: config.writeTo(SD, "config.json"); */
-  void writeTo(FS& fs, const char* path);
 };
 
 #endif // CONFIG_H_20220712

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -19,9 +19,8 @@ void Config::save() {
   pref.putInt("co2_interval", co2_interval);
   pref.putInt("soil_interval", soil_interval);
   pref.putInt("inter_times", intermix_times);
-  pref.putInt("inter_done", intermix_done_count);
   pref.putInt("inter_duration", intermix_duration);
-  pref.putInt("sleep_duration", sleep_duration);
+  pref.putInt("sleep_duration", sleep_duration_minutes);
   pref.putString("logfilename", logfilename);
   pref.putString("serial_number", serial_number);
   pref.putInt("flow_meas_time", flow_meas_time);
@@ -43,10 +42,9 @@ void Config::restore() {
   postmix_time = pref.getInt("postmix_time", postmix_time);
   co2_interval = pref.getInt("co2_interval", co2_interval);
   soil_interval = pref.getInt("soil_interval", soil_interval);
-  intermix_times = pref.getInt("soil_interval", intermix_times);
-  intermix_done_count = pref.getInt("inter_done", intermix_done_count);
+  intermix_times = pref.getInt("inter_times", intermix_times);
   intermix_duration = pref.getInt("inter_duration", intermix_duration);
-  sleep_duration = pref.getInt("sleep_duration", sleep_duration);
+  sleep_duration_minutes = pref.getInt("sleep_duration", sleep_duration_minutes);
   logfilename = pref.getString("logfilename", logfilename);
   serial_number = pref.getString("serial_number", serial_number);
   flow_meas_time = pref.getInt("flow_meas_time", flow_meas_time);
@@ -74,7 +72,7 @@ std::string Config::dumps() {
                            {"intermix_times", this->intermix_times},
                            {"intermix_duration", this->intermix_duration},
                            {"soil_interval", this->soil_interval},
-                           {"sleep_duration", this->sleep_duration},
+                           {"sleep_duration", this->sleep_duration_minutes},
                            {"log_file_name", this->logfilename.c_str()},
                            {"location_notes", this->location_notes.c_str()},
                            {"flow_meas_time", this->flow_meas_time},

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -18,6 +18,9 @@ void Config::save() {
   pref.putInt("postmix_time", postmix_time);
   pref.putInt("co2_interval", co2_interval);
   pref.putInt("soil_interval", soil_interval);
+  pref.putInt("inter_times", intermix_times);
+  pref.putInt("inter_done", intermix_done_count);
+  pref.putInt("inter_duration", intermix_duration);
   pref.putInt("sleep_duration", sleep_duration);
   pref.putString("logfilename", logfilename);
   pref.putString("serial_number", serial_number);
@@ -40,6 +43,9 @@ void Config::restore() {
   postmix_time = pref.getInt("postmix_time", postmix_time);
   co2_interval = pref.getInt("co2_interval", co2_interval);
   soil_interval = pref.getInt("soil_interval", soil_interval);
+  intermix_times = pref.getInt("soil_interval", intermix_times);
+  intermix_done_count = pref.getInt("inter_done", intermix_done_count);
+  intermix_duration = pref.getInt("inter_duration", intermix_duration);
   sleep_duration = pref.getInt("sleep_duration", sleep_duration);
   logfilename = pref.getString("logfilename", logfilename);
   serial_number = pref.getString("serial_number", serial_number);
@@ -65,6 +71,8 @@ std::string Config::dumps() {
                            {"meas_time", this->meas_time},
                            {"postmix_time", this->postmix_time},
                            {"co2_interval", this->co2_interval},
+                           {"intermix_times", this->intermix_times},
+                           {"intermix_duration", this->intermix_duration},
                            {"soil_interval", this->soil_interval},
                            {"sleep_duration", this->sleep_duration},
                            {"log_file_name", this->logfilename},
@@ -74,56 +82,4 @@ std::string Config::dumps() {
   return configuration.dump();
 }
 
-///@deprecated
-void Config::readFrom(FS& fs, const char* path) {
-  if (!fs.exists(path)) {
-    log_i("File %s doesn't exist, NOT creating default file", path);
-    // writeConfig(); //TODO: Should we write a default config?
-    return;
-  }
 
-  auto file = fs.open(path, FILE_READ);
-  if (!file) {
-    // If we don't have file we stop
-    log_e("SD Card failed to open!");
-    for (;;) // TODO: Fault tolerance
-      ;
-  }
-  std::string buf = "";
-  while (file.available()) {
-    buf += file.read();
-  }
-  file.close();
-  std::string err;
-  json11::Json configuration = json11::Json::parse(buf, err);
-  // TODO: Check for failed JSON parse
-  int version = configuration["version"].int_value();
-  if (version == 1) {
-    this->latitude = configuration["latitude"].int_value();
-    this->longitude = configuration["longitude"].int_value();
-    this->warmup_time = configuration["warmup_time"].int_value();
-    this->premix_time = configuration["premix_time"].int_value();
-    this->meas_time = configuration["meas_time"].int_value();
-    this->postmix_time = configuration["postmix_time"].int_value();
-    this->co2_interval = configuration["co2_interval"].int_value();
-    this->soil_interval = configuration["soil_interval"].int_value();
-    this->sleep_duration = configuration["sleep_duration"].int_value();
-    this->logfilename = configuration["log_file_name"].string_value().c_str();
-  } else {
-    log_e("Read configuration file of unsupported version");
-  }
-}
-///@deprecated
-void Config::writeTo(FS& fs, const char* path) {
-  log_i("Creating file %s", path);
-  fs.remove(path);
-  auto file = fs.open(path, FILE_WRITE);
-  if (!file) {
-    // If we don't have file we stop //TODO: fault tolerance
-    log_fail("SD Card failed to open!", false, true);
-  }
-  // Write config to file
-  std::string conf_str = this->dumps();
-  file.write((const uint8_t*)conf_str.data(), conf_str.length());
-  file.close();
-}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,7 +262,7 @@ void initialConfig() {
 
 String selfTest() {
   std::stringstream ss{};
-  ss << "Power on self test\nChamber firmware v0.2" << std::endl;
+  ss << "Power on self test\nChamber firmware v0.3" << std::endl;
   // Set up serial port for SCD30
   Serial1.begin(19200, SERIAL_8N1, PIN_UART_RX, PIN_UART_TX);
   // Check SD

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -53,7 +53,7 @@ String index_template_processor(Config* config, const String& var) {
   } else if (var == "sizelist") {
     return index_filelist(true); //TODO: This can be cleaned up
   } else if (var == "co2interval") {
-    return std::to_string(config->sleep_duration).c_str();
+    return std::to_string(config->sleep_duration_minutes).c_str();
   } else if (var == "co2lograte") {
     return std::to_string(config->co2_interval).c_str();
   } else if (var == "soillograte") {
@@ -158,7 +158,7 @@ void web_setup_task(void* params) {
         }
       FROM_PARAM(config->latitude, "lat", .toFloat());
       FROM_PARAM(config->longitude, "lon", .toFloat());
-      FROM_PARAM(config->sleep_duration, "co2interval", .toInt());
+      FROM_PARAM(config->sleep_duration_minutes, "co2interval", .toInt());
       FROM_PARAM(config->co2_interval, "co2lograte", .toInt());
       FROM_PARAM(config->soil_interval, "soillograte", .toInt());
       FROM_PARAM(config->intermix_times, "intermixtimes", .toInt());

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -51,13 +51,17 @@ String index_template_processor(Config* config, const String& var) {
   } else if (var == "filelist") {
     return index_filelist();
   } else if (var == "sizelist") {
-    return index_filelist(true);
+    return index_filelist(true); //TODO: This can be cleaned up
   } else if (var == "co2interval") {
     return std::to_string(config->sleep_duration).c_str();
   } else if (var == "co2lograte") {
     return std::to_string(config->co2_interval).c_str();
   } else if (var == "soillograte") {
     return std::to_string(config->soil_interval).c_str();
+  } else if (var == "intermixtimes") {
+    return std::to_string(config->intermix_times).c_str();
+  } else if (var == "intermixduration") {
+    return std::to_string(config->intermix_duration).c_str();
   } else if (var == "warmupduration") {
     return std::to_string(config->warmup_time).c_str();
   } else if (var == "premixduration") {
@@ -157,6 +161,8 @@ void web_setup_task(void* params) {
       FROM_PARAM(config->sleep_duration, "co2interval", .toInt());
       FROM_PARAM(config->co2_interval, "co2lograte", .toInt());
       FROM_PARAM(config->soil_interval, "soillograte", .toInt());
+      FROM_PARAM(config->intermix_times, "intermixtimes", .toInt());
+      FROM_PARAM(config->intermix_duration, "intermixduration", .toInt());
       FROM_PARAM(config->warmup_time, "warmupduration", .toInt());
       FROM_PARAM(config->premix_time, "premixduration", .toInt());
       FROM_PARAM(config->meas_time, "valvesclosedduration", .toInt());


### PR DESCRIPTION
Adds the ability to specify a number of fan-on mixing periods between measurements.

Intermix times in the web interface specifies how many times the mixing will occur, evenly spaced between every two measurements, and intermix duration specifies how long the fan will be turned on for each of them.

This also adds logging for when the fan is turned on and off, and for when the valves are closed and opened, see cee8ea9.